### PR TITLE
vLLM CPU: Fix Triton Version to Resolve Related Error

### DIFF
--- a/docker/llm/serving/cpu/docker/Dockerfile
+++ b/docker/llm/serving/cpu/docker/Dockerfile
@@ -100,7 +100,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pip uninstall -y intel-extension-for-pytorch && \
     pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu && \
     VLLM_TARGET_DEVICE=cpu python3 setup.py install && \
-    pip install ray && \
+    pip install ray triton==3.1.0 && \
 # Clean up unnecessary files to reduce image size
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

The recent released version of triton (`triton==3.2.0`) is somehow incompatible with torch 2.5.1+cpu. Needs to fix it to a validated version (3.1.0). 