### PR TITLE
docs: Add `--entrypoint /bin/bash` to docker run commands for serving-xpu image

### DIFF
--- a/docker/llm/serving/xpu/docker/README.md
+++ b/docker/llm/serving/xpu/docker/README.md
@@ -26,7 +26,7 @@ To map the `XPU` into the container, you need to specify `--device=/dev/dri` whe
 
 ```bash
 #/bin/bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-xpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
 
 sudo docker run -itd \
         --net=host \
@@ -34,6 +34,7 @@ sudo docker run -itd \
         --memory="32G" \
         --name=CONTAINER_NAME \
         --shm-size="16g" \
+        --entrypoint /bin/bash \
         $DOCKER_IMAGE
 ```
 
@@ -71,7 +72,7 @@ By default, the container is configured to automatically start the service when 
 
 ```bash
 #/bin/bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-xpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
 
 sudo docker run -itd \
         --net=host \
@@ -110,7 +111,7 @@ If you prefer to manually start the service or need to troubleshoot, you can ove
 
 ```bash
 #/bin/bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-xpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
 
 sudo docker run -itd \
         --net=host \

--- a/docs/mddocs/DockerGuides/docker_pytorch_inference_gpu.md
+++ b/docs/mddocs/DockerGuides/docker_pytorch_inference_gpu.md
@@ -32,6 +32,7 @@ Start ipex-llm-xpu Docker Container. Choose one of the following commands to sta
              --name=$CONTAINER_NAME \
              --shm-size="16g" \
              -v $MODEL_PATH:/llm/models \
+             --entrypoint /bin/bash \
              $DOCKER_IMAGE
   ```
 
@@ -52,6 +53,7 @@ Start ipex-llm-xpu Docker Container. Choose one of the following commands to sta
                   --shm-size="16g" \
                   -v $MODEL_PATH:/llm/llm-models \
                   -v /usr/lib/wsl:/usr/lib/wsl \ 
+                  --entrypoint /bin/bash \
                   $DOCKER_IMAGE
   ```
 

--- a/docs/mddocs/DockerGuides/docker_run_pytorch_inference_in_vscode.md
+++ b/docs/mddocs/DockerGuides/docker_run_pytorch_inference_in_vscode.md
@@ -66,6 +66,7 @@ Start ipex-llm-serving-xpu Docker Container. Choose one of the following command
              --name=$CONTAINER_NAME \
              --shm-size="16g" \
              -v $MODEL_PATH:/llm/models \
+             --entrypoint /bin/bash \
              $DOCKER_IMAGE
   ```
 
@@ -86,6 +87,7 @@ Start ipex-llm-serving-xpu Docker Container. Choose one of the following command
                   --shm-size="16g" \
                   -v $MODEL_PATH:/llm/llm-models \
                   -v /usr/lib/wsl:/usr/lib/wsl \ 
+                  --entrypoint /bin/bash \
                   $DOCKER_IMAGE
   ```
 

--- a/docs/mddocs/DockerGuides/fastchat_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/fastchat_docker_quickstart.md
@@ -29,6 +29,7 @@ sudo docker run -itd \
         --memory="32G" \
         --name=$CONTAINER_NAME \
         --shm-size="16g" \
+        --entrypoint /bin/bash \
         $DOCKER_IMAGE
 ```
 

--- a/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
@@ -32,6 +32,7 @@ sudo docker run -itd \
         --memory="32G" \
         --name=$CONTAINER_NAME \
         --shm-size="16g" \
+        --entrypoint /bin/bash \
         $DOCKER_IMAGE
 ```
 
@@ -835,6 +836,7 @@ We can set up model serving using `IPEX-LLM` as backend using FastChat, the foll
             -e http_proxy=... \ 
             -e https_proxy=... \
             -e no_proxy="127.0.0.1,localhost" \
+            --entrypoint /bin/bash \
             $DOCKER_IMAGE
     ```
 

--- a/python/llm/dev/benchmark/ceval/README.md
+++ b/python/llm/dev/benchmark/ceval/README.md
@@ -64,6 +64,7 @@ python eval.py \
          -e http_proxy=$HTTP_PROXY \
          -e https_proxy=$HTTPS_PROXY \
          --shm-size="16g" \
+         --entrypoint /bin/bash \
          $DOCKER_IMAGE
    ```
 


### PR DESCRIPTION
## Description

This PR modifies the documentation for launching the serving-xpu Docker container to include `--entrypoint /bin/bash` in the `docker run` command. 

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
