### PR TITLE
Fix qwen nan value issue on vllm

### DIFF
--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -107,6 +107,12 @@ def get_load_function(low_bit):
                     modules = ["35.mlp", "36.mlp", "37.mlp", "38.mlp", "39.mlp"]
                 else:
                     modules = None
+                not_convert_o_proj = os.getenv("IPEX_LLM_NOT_CONVERT_O_PROJ", None)
+                if not_convert_o_proj is not None:
+                    # only use to avoid nan value in o_proj forward running DeepSeek-R1-Distill-Qwen-14B
+                    modules = ["o_proj"]
+                else:
+                    modules = None
                 if "minicpm" in self.vllm_config.model_config.model.lower():
                     modules = ["vpm", "resampler"]
                 if "internvl2" in self.vllm_config.model_config.model.lower():

--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -109,7 +109,7 @@ def get_load_function(low_bit):
                     modules = None
                 not_convert_o_proj = os.getenv("IPEX_LLM_NOT_CONVERT_O_PROJ", None)
                 if not_convert_o_proj is not None:
-                    # only use to avoid nan value in o_proj forward running DeepSeek-R1-Distill-Qwen-14B
+                    # only use to avoid nan value in o_proj running DeepSeek-R1-Distill-Qwen-14B
                     modules = ["o_proj"]
                 else:
                     modules = None


### PR DESCRIPTION
## Description
Fix qwen nan value issue on vllm. Refer to [this issue](https://github.com/analytics-zoo/nano/issues/1898).

export `IPEX_LLM_NOT_CONVERT_O_PROJ` = 1 and set ["rms_norm_eps": 1e-05](https://hf-mirror.com/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B/blob/main/config.json#L18) to 1e0-4 to fix.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
