### PR TITLE
Fix vllm glm edge model

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -192,7 +192,8 @@ def is_linear_module(module):
                and hasattr(module.quant_method, "quant_config")
                and module.quant_method.quant_config.get_name() == "gptq"):
                 _USE_VLLM_GPTQ = True
-            invalidInputError(module.skip_bias_add is not True, "Currently, ipex-vllm does not"
+            invalidInputError(module.skip_bias_add is not True or module.bias is None,
+                               "Currently, ipex-vllm does not"
                               " support linear layers with skip_bias_add argument")
             if isinstance(module, RowParallelLinear) and tp_size >= 2:
                 mp_group = get_tensor_model_parallel_group()

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -193,7 +193,7 @@ def is_linear_module(module):
                and module.quant_method.quant_config.get_name() == "gptq"):
                 _USE_VLLM_GPTQ = True
             invalidInputError(module.skip_bias_add is not True or module.bias is None,
-                               "Currently, ipex-vllm does not"
+                              "Currently, ipex-vllm does not"
                               " support linear layers with skip_bias_add argument")
             if isinstance(module, RowParallelLinear) and tp_size >= 2:
                 mp_group = get_tensor_model_parallel_group()


### PR DESCRIPTION
## Description

ipex-llm does not obey `skip_bias_add` argument.

It always add the bias if bias is not None.

But we can safely expand the check condition based on this rule to support glm-edge-4B-Chat model

