### PR TITLE
set woq_int4 as default int4

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -1090,10 +1090,14 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          mixed_precision=False,
                          disable_optimize_pre=False):
     if qtype == ggml_tensor_qtype["sym_int4"] and torch.__version__ >= "2.6":
-        logger.info(f"sym_int4 is deprecated, use woq_int4 instead")
-        logger.info(f"if you are loading saved sym_int4 low bit model, "
-                    "please resaved it with woq_int4")
+        logger.warning("sym_int4 is deprecated, use woq_int4 instead, "
+                       "if you are loading saved sym_int4 low bit model, "
+                       "please resaved it with woq_int4")
         qtype = ggml_tensor_qtype["woq_int4"]
+    elif qtype == ggml_tensor_qtype["woq_int4"] and torch.__version__ < "2.6":
+        logger.warning("woq_int4 is not supported with pytorch<2.6, "
+                       "use sym_int4 instead or use ipex-llm with pytorch>=2.6")
+        qtype = ggml_tensor_qtype["sym_int4"]
     if qtype in ggml_tensor_qtype.values():
         index = list(ggml_tensor_qtype.values()).index(qtype)
         logger.info(f"Converting the current model to "

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -1089,7 +1089,7 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          embedding_qtype=None,
                          mixed_precision=False,
                          disable_optimize_pre=False):
-    if qtype == ggml_tensor_qtype["sym_int4"]:
+    if qtype == ggml_tensor_qtype["sym_int4"] and torch.__version__ >= "2.6":
         logger.info(f"sym_int4 is deprecated, use woq_int4 instead")
         logger.info(f"if you are loading saved sym_int4 low bit model, "
                     "please resaved it with woq_int4")

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -1090,7 +1090,7 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          mixed_precision=False,
                          disable_optimize_pre=False):
     if qtype == ggml_tensor_qtype["sym_int4"]:
-        logger.info(f"sym_int4 is deprecated, use woq_int4 instead.")
+        logger.info(f"sym_int4 is deprecated, use woq_int4 instead")
         logger.info(f"if you are loading saved sym_int4 low bit model, "
                     "please resaved it with woq_int4")
         qtype = ggml_tensor_qtype["woq_int4"]

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -1089,6 +1089,11 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          embedding_qtype=None,
                          mixed_precision=False,
                          disable_optimize_pre=False):
+    if qtype == ggml_tensor_qtype["sym_int4"]:
+        logger.info(f"sym_int4 is deprecated, use woq_int4 instead.")
+        logger.info(f"if you are loading saved sym_int4 low bit model, "
+                    "please resaved it with woq_int4")
+        qtype = ggml_tensor_qtype["woq_int4"]
     if qtype in ggml_tensor_qtype.values():
         index = list(ggml_tensor_qtype.values()).index(qtype)
         logger.info(f"Converting the current model to "


### PR DESCRIPTION
# Description

this PR will map `load_in_4bit=True` or `load_in_low_bit='sym_int4'` to `load_in_low_bit='woq_int4'` automatically in torch 2.6

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
