### PR TITLE
Fix: pin cmake version in cpu serving dockerfile to resolve build issue 

### DIFF
--- a/docker/llm/serving/cpu/docker/Dockerfile
+++ b/docker/llm/serving/cpu/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git clone https://github.com/vllm-project/vllm.git && \
     cd ./vllm && \
     git checkout v0.6.6.post1 && \
-    pip install cmake>=3.26 wheel packaging ninja "setuptools-scm>=8" numpy && \
+    pip install cmake==3.31 wheel packaging ninja "setuptools-scm>=8" numpy && \
     pip uninstall -y intel-extension-for-pytorch && \
     pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu && \
     VLLM_TARGET_DEVICE=cpu python3 setup.py install && \

--- a/docker/llm/serving/cpu/docker/Dockerfile
+++ b/docker/llm/serving/cpu/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git clone https://github.com/vllm-project/vllm.git && \
     cd ./vllm && \
     git checkout v0.6.6.post1 && \
-    pip install cmake==3.31 wheel packaging ninja "setuptools-scm>=8" numpy && \
+    pip install cmake==3.31.6 wheel packaging ninja "setuptools-scm>=8" numpy && \
     pip uninstall -y intel-extension-for-pytorch && \
     pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu && \
     VLLM_TARGET_DEVICE=cpu python3 setup.py install && \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Pin cmake version to 3.31.6 in cpu serving dockerfile to resolve vLLM build issue.
