### PR TITLE
Update documentation to build Docker image from Dockerfile instead of pulling from registry

### DIFF
--- a/docker/llm/finetune/xpu/README.md
+++ b/docker/llm/finetune/xpu/README.md
@@ -16,13 +16,7 @@ With this docker image, we can use all [ipex-llm finetune examples on Intel GPU]
 
 ## 1. Prepare Docker Image
 
-You can download directly from Dockerhub like:
-
-```bash
-docker pull intelanalytics/ipex-llm-finetune-xpu:2.2.0-SNAPSHOT
-```
-
-Or build the image from source:
+TO build the image from source:
 
 ```bash
 export HTTP_PROXY=your_http_proxy
@@ -31,7 +25,7 @@ export HTTPS_PROXY=your_https_proxy
 docker build \
   --build-arg http_proxy=${HTTP_PROXY} \
   --build-arg https_proxy=${HTTPS_PROXY} \
-  -t intelanalytics/ipex-llm-finetune-xpu:2.2.0-SNAPSHOT \
+  -t intelanalytics/ipex-llm-finetune-xpu:latest \
   -f ./Dockerfile .
 ```
 
@@ -55,7 +49,7 @@ docker run -itd \
    -v $BASE_MODE_PATH:/model \
    -v $DATA_PATH:/data/alpaca-cleaned \
    --shm-size="16g" \
-   intelanalytics/ipex-llm-finetune-xpu:2.2.0-SNAPSHOT
+   intelanalytics/ipex-llm-finetune-xpu:latest
 ```
 
 The download and mount of base model and data to a docker container demonstrates a standard fine-tuning process. You can skip this step for a quick start, and in this way, the fine-tuning codes will automatically download the needed files:
@@ -72,7 +66,7 @@ docker run -itd \
    -e http_proxy=${HTTP_PROXY} \
    -e https_proxy=${HTTPS_PROXY} \
    --shm-size="16g" \
-   intelanalytics/ipex-llm-finetune-xpu:2.2.0-SNAPSHOT
+   intelanalytics/ipex-llm-finetune-xpu:latest
 ```
 
 However, we do recommend you to handle them manually, because the download can be blocked by Internet access and Huggingface authentication etc. according to different environment, and the manual method allows you to fine-tune in a custom way (with different base model and dataset).

--- a/docker/llm/inference-cpp/README.md
+++ b/docker/llm/inference-cpp/README.md
@@ -13,11 +13,17 @@
 #### Setting Docker on windows
 Need to enable `--net=host`,follow [this guide](https://docs.docker.com/network/drivers/host/#docker-desktop) so that you can easily access the service running on the docker. The [v6.1x kernel version wsl]( https://learn.microsoft.com/en-us/community/content/wsl-user-msft-kernel-v6#1---building-the-microsoft-linux-kernel-v61x) is recommended to use.Otherwise, you may encounter the blocking issue before loading the model to GPU.
 
-### Pull the latest image
+### Build the Image
+To build the `ipex-llm-inference-cpp-xpu` Docker image, use the following command:
+
 ```bash
-# This image will be updated every day
-docker pull intelanalytics/ipex-llm-inference-cpp-xpu:latest
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm-inference-cpp-xpu:latest .
 ```
+
 
 ### Start Docker Container
 

--- a/docker/llm/serving/cpu/docker/README.md
+++ b/docker/llm/serving/cpu/docker/README.md
@@ -14,7 +14,7 @@ docker build \
   --build-arg http_proxy=.. \
   --build-arg https_proxy=.. \
   --build-arg no_proxy=.. \
-  --rm --no-cache -t intelanalytics/ipex-llm-serving-cpu:2.2.0-SNAPSHOT .
+  --rm --no-cache -t intelanalytics/ipex-llm-serving-cpu:latest .
 ```
 
 ---
@@ -40,7 +40,7 @@ This ensures the container has access to the necessary models.
 Use the following command to start the container:  
 
 ```bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-cpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-cpu:latest
 
 sudo docker run -itd \
         --net=host \  # Use host networking for performance

--- a/docker/llm/serving/xpu/docker/README.md
+++ b/docker/llm/serving/xpu/docker/README.md
@@ -73,7 +73,7 @@ By default, the container is configured to automatically start the service when 
 
 ```bash
 #/bin/bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:latest
 
 sudo docker run -itd \
         --net=host \
@@ -113,7 +113,7 @@ If you prefer to manually start the service or need to troubleshoot, you can ove
 
 ```bash
 #/bin/bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:latest
 
 sudo docker run -itd \
         --net=host \

--- a/docker/llm/serving/xpu/docker/README.md
+++ b/docker/llm/serving/xpu/docker/README.md
@@ -13,7 +13,7 @@ docker build \
   --build-arg http_proxy=.. \
   --build-arg https_proxy=.. \
   --build-arg no_proxy=.. \
-  --rm --no-cache -t intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT .
+  --rm --no-cache -t intelanalytics/ipex-llm-serving-xpu:latest .
 ```
 
 ---
@@ -26,11 +26,12 @@ To map the `XPU` into the container, you need to specify `--device=/dev/dri` whe
 
 ```bash
 #/bin/bash
-export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
+export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:latest
 
 sudo docker run -itd \
         --net=host \
         --device=/dev/dri \
+        --privileged \
         --memory="32G" \
         --name=CONTAINER_NAME \
         --shm-size="16g" \
@@ -117,6 +118,7 @@ export DOCKER_IMAGE=intelanalytics/ipex-llm-serving-xpu:2.2.0-SNAPSHOT
 sudo docker run -itd \
         --net=host \
         --device=/dev/dri \
+        --privileged \
         --memory="32G" \
         --name=CONTAINER_NAME \
         --shm-size="16g" \

--- a/docs/mddocs/DockerGuides/docker_cpp_xpu_quickstart.md
+++ b/docs/mddocs/DockerGuides/docker_cpp_xpu_quickstart.md
@@ -20,6 +20,7 @@ Need to enable `--net=host`,follow [this guide](https://docs.docker.com/network/
 To build the `ipex-llm-inference-cpp-xpu` Docker image, use the following command:
 
 ```bash
+cd docker/llm/inference-cpp
 docker build \
   --build-arg http_proxy=.. \
   --build-arg https_proxy=.. \

--- a/docs/mddocs/DockerGuides/docker_cpp_xpu_quickstart.md
+++ b/docs/mddocs/DockerGuides/docker_cpp_xpu_quickstart.md
@@ -16,10 +16,15 @@
 
 Need to enable `--net=host`,follow [this guide](https://docs.docker.com/network/drivers/host/#docker-desktop) so that you can easily access the service running on the docker. The [v6.1x kernel version wsl]( https://learn.microsoft.com/en-us/community/content/wsl-user-msft-kernel-v6#1---building-the-microsoft-linux-kernel-v61x) is recommended to use.Otherwise, you may encounter the blocking issue before loading the model to GPU.
 
-### Pull the latest image
+### Build the Image
+To build the `ipex-llm-inference-cpp-xpu` Docker image, use the following command:
+
 ```bash
-# This image will be updated every day
-docker pull intelanalytics/ipex-llm-inference-cpp-xpu:latest
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm-inference-cpp-xpu:latest .
 ```
 
 ### Start Docker Container

--- a/docs/mddocs/DockerGuides/docker_pytorch_inference_gpu.md
+++ b/docs/mddocs/DockerGuides/docker_pytorch_inference_gpu.md
@@ -13,7 +13,12 @@ Follow the [Docker installation Guide](./docker_windows_gpu.md#install-docker) t
 
 Prepare ipex-llm-serving-xpu Docker Image:
 ```bash
-docker pull intelanalytics/ipex-llm-serving-xpu:latest
+cd docker/llm/serving/xpu/docker
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm-serving-xpu:latest .
 ```
 
 Start ipex-llm-xpu Docker Container. Choose one of the following commands to start the container:

--- a/docs/mddocs/DockerGuides/fastchat_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/fastchat_docker_quickstart.md
@@ -6,11 +6,16 @@ This guide demonstrates how to run `FastChat` serving with `IPEX-LLM` on Intel G
 
 Follow the instructions in this [guide](./docker_windows_gpu.md#linux) to install Docker on Linux.
 
-## Pull the latest image
+## Build the Image
+To build the `ipex-llm-serving-xpu` Docker image, use the following command:
 
 ```bash
-# This image will be updated every day
-docker pull intelanalytics/ipex-llm-serving-xpu:latest
+cd docker/llm/serving/xpu/docker
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm-serving-xpu:latest .
 ```
 
 ## Start Docker Container

--- a/docs/mddocs/DockerGuides/vllm_cpu_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/vllm_cpu_docker_quickstart.md
@@ -6,13 +6,17 @@ This guide demonstrates how to run `vLLM` serving with `ipex-llm` on Intel CPU v
 
 Follow the instructions in this [guide](https://www.docker.com/get-started/) to install Docker on Linux.
 
-## Pull the latest image
 
-*Note: For running vLLM serving on Intel CPUs, you can currently use either the `intelanalytics/ipex-llm-serving-cpu:latest` or `intelanalytics/ipex-llm-serving-vllm-cpu:latest` Docker image.*
+## Build the Image
+To build the `ipex-llm-serving-cpu` Docker image, use the following command:
 
 ```bash
-# This image will be updated every day
-docker pull intelanalytics/ipex-llm-serving-cpu:latest
+cd docker/llm/serving/cpu/docker
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm-serving-cpu:latest .
 ```
 
 ## Start Docker Container

--- a/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
@@ -6,13 +6,16 @@ This guide demonstrates how to run `vLLM` serving with `IPEX-LLM` on Intel GPUs 
 
 Follow the instructions in this [guide](./docker_windows_gpu.md#linux) to install Docker on Linux.
 
-## Pull the latest image
-
-*Note: For running vLLM serving on Intel GPUs, you can currently use either the `intelanalytics/ipex-llm-serving-xpu:latest` or `intelanalytics/ipex-llm-serving-vllm-xpu:latest` Docker image.*
+## Build the Image
+To build the `ipex-llm-serving-xpu` Docker image, use the following command:
 
 ```bash
-# This image will be updated every day
-docker pull intelanalytics/ipex-llm-serving-xpu:latest
+cd docker/llm/serving/xpu/docker
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm-serving-xpu:latest .
 ```
 
 ## Start Docker Container


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This PR updates the documentation to instruct users to build the Docker image locally using the provided Dockerfile, instead of pulling it from a registry.

The change is necessary because the Docker image is not publicly released as part of our distribution. Building it locally ensures users can still proceed without relying on an external image registry.

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
