### PR TITLE
Update compute-runtime for BMG support

### DIFF
--- a/docker/llm/serving/xpu/docker/1ccl_for_multi_arc.patch
+++ b/docker/llm/serving/xpu/docker/1ccl_for_multi_arc.patch
@@ -1,7 +1,9 @@
-From d345631f78a2f33ff1ddd7d9908b288eb0afaf46 Mon Sep 17 00:00:00 2001
-From: Huajun Li <huajun.li@.com>
-Date: Fri, 24 May 2024 09:47:26 +0800
-Subject: [PATCH 1/3] allreduce optimization with LL256 for Arc770 dGPU
+From 37031b32dc98214b37beed024dd4af07bcf87ed1 Mon Sep 17 00:00:00 2001
+From: Zhu Yong <yong.zhu@intel.com>
+Date: Fri, 25 Apr 2025 08:52:42 +0800
+Subject: [PATCH] allreduce for BMG V2025.0.0.1.0
+
+allreduce optimization with LL256 P2P for BMG dGPU
 
 To enable this feature, please set env var:
     export CCL_DG2_ALLREDUCE=1
@@ -12,6 +14,23 @@ Build:
     3. cmake .. -GNinja -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS="-fsycl" -DCOMPUTE_BACKEND=dpcpp  -DCMAKE_BUILD_TYPE=MinSizeRel
     4. ninja
     5. ls -al src/libccl*
+
+Changes:
+optimize req_workgroup calculate
+
+Revert "optimize req_workgroup calculate" for hang issue
+
+This reverts commit 20bfd0e0a37f93dfb8bb9c092cd5a0b35e868bfa.
+
+enable BMG usm
+
+fix data overflow
+
+fix data ovrewrite for sum
+
+fix data over for special size 18186176
+
+enable p2p allreduce
 ---
  src/CMakeLists.txt               |   2 +
  src/coll/coll.cpp                |  30 +-
@@ -20,9 +39,9 @@ Build:
  src/common/env/env.cpp           |   1 +
  src/common/env/env.hpp           |   1 +
  src/common/env/vars.hpp          |   1 +
- src/dg2/dg2_allreduce.cpp        | 642 +++++++++++++++++++++++++++++++
+ src/dg2/dg2_allreduce.cpp        | 688 +++++++++++++++++++++++++++++++
  src/dg2/dg2_allreduce.hpp        |  13 +
- 9 files changed, 693 insertions(+), 3 deletions(-)
+ 9 files changed, 739 insertions(+), 3 deletions(-)
  create mode 100644 src/dg2/dg2_allreduce.cpp
  create mode 100644 src/dg2/dg2_allreduce.hpp
 
@@ -163,10 +182,10 @@ index 73dcf77..84ab518 100644
  constexpr const char* CCL_MIN_CHUNK_SIZE = "CCL_MIN_CHUNK_SIZE";
 diff --git a/src/dg2/dg2_allreduce.cpp b/src/dg2/dg2_allreduce.cpp
 new file mode 100644
-index 0000000..15ace74
+index 0000000..a932f19
 --- /dev/null
 +++ b/src/dg2/dg2_allreduce.cpp
-@@ -0,0 +1,642 @@
+@@ -0,0 +1,688 @@
 +#include <fcntl.h>
 +#include <unistd.h>
 +#include <sys/un.h>
@@ -191,6 +210,8 @@ index 0000000..15ace74
 +#include "common/utils/exchange_utils.hpp"
 +
 +#include "dg2_allreduce.hpp"
++
++#define XE_PLUS
 +
 +using namespace std;
 +using namespace sycl;
@@ -223,6 +244,8 @@ index 0000000..15ace74
 +    __asm__ __volatile__("lsc_load.ugm.uc.uc   (M1, 16)  %0:d32x4  flat[%1]:a64" : "=rw"(reinterpret_cast<typename message_t::vector_t &>(var)) : "rw"(addr) : "memory")
 +#define __LscLoadCachedVec(var, addr)   \
 +    __asm__ __volatile__("lsc_load.ugm.ca.ca   (M1, 16)  %0:d32x4  flat[%1]:a64" : "=rw"(reinterpret_cast<typename message_t::vector_t &>(var)) : "rw"(addr) : "memory")
++#define __LscLoadL3CachedVec(var, addr)   \
++    __asm__ __volatile__("lsc_load.ugm.uc.ca   (M1, 16)  %0:d32x4  flat[%1]:a64" : "=rw"(reinterpret_cast<typename message_t::vector_t &>(var)) : "rw"(addr) : "memory")
 +
 +#define __LscStoreUnCached(addr, var)  \
 +    __asm__ __volatile__("lsc_store.ugm.uc.uc  (M1, 16)  flat[%0]:a64  %1:d64" : : "rw"(addr), "rw"(var) : "memory")
@@ -235,6 +258,7 @@ index 0000000..15ace74
 +
 +#define LscLoadCached     __LscLoadCachedVec
 +#define LscLoadUnCached   __LscLoadUnCachedVec
++#define LscLoadL3Cached   __LscLoadL3CachedVec
 +#define LscStoreCached    __LscStoreCachedVec
 +#define LscStoreUnCached  __LscStoreUnCachedVec
 +
@@ -386,7 +410,8 @@ index 0000000..15ace74
 +    pthread_create(&tid, nullptr, thread_func, &world_rank);
 +
 +    size_t buf_size = LL256_BUF_SIZE;
-+    host_buf = sycl::aligned_alloc_device(getpagesize(), buf_size, q);
++   host_buf = sycl::aligned_alloc_device(getpagesize(), buf_size, q);
++   //host_buf = sycl::aligned_alloc_host(getpagesize(), buf_size, q);
 +
 +    host_bufs[world_rank] = host_buf;
 +
@@ -476,7 +501,12 @@ index 0000000..15ace74
 +    auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
 +
 +    do {
++#if defined(XE_PLUS)
++       LscLoadL3Cached(data, src + lid * sz);
++#else
 +        LscLoadUnCached(data, src + lid * sz);
++#endif
++
 +    } while (sycl::any_of_group(sg, ((lid ==  3) && (data[3] != pattern)) ||
 +                                    ((lid ==  7) && (data[3] != pattern)) ||
 +                                    ((lid == 11) && (data[3] != pattern)) ||
@@ -485,41 +515,68 @@ index 0000000..15ace74
 +
 +static inline void shuffle_data(message_t &data)
 +{
++#if defined(XE_PLUS)
++    __asm__ __volatile__("mov (M1, 1) %0(0, 15)<1> %0(3, 3)<0;1,0>\n"
++                         "mov (M1, 1) %0(1, 15)<1> %0(3, 7)<0;1,0>\n"
++                         "mov (M1, 1) %0(2, 15)<1> %0(3, 11)<0;1,0>\n"
++                         : "+rw"(reinterpret_cast<typename message_t::vector_t &>(data))
++                         : );
++#else
++
 +    __asm__ __volatile__("mov (M1, 1) %0(1, 7)<1> %0(6, 3)<0;1,0>\n"
 +                         "mov (M1, 1) %0(3, 7)<1> %0(6, 7)<0;1,0>\n"
 +                         "mov (M1, 1) %0(5, 7)<1> %0(7, 3)<0;1,0>\n"
 +                         : "+rw"(reinterpret_cast<typename message_t::vector_t &>(data))
 +                         : );
++#endif
 +}
 +
 +static inline void insert_pattern(message_t &data, pattern_t pattern)
 +{
++#if defined(XE_PLUS)
++    __asm__ __volatile__("mov (M1, 1) %0(3, 3)<1> %1(0, 0)<0;1,0>\n"
++                         "mov (M1, 1) %0(3, 7)<1> %1(0, 0)<0;1,0>\n"
++                         "mov (M1, 1) %0(3, 11)<1> %1(0, 0)<0;1,0>\n"
++                         "mov (M1, 1) %0(3, 15)<1> %1(0, 0)<0;1,0>\n"
++                         : "+rw"(reinterpret_cast<typename message_t::vector_t &>(data))
++                         : "rw"(pattern));
++#else
 +    __asm__ __volatile__("mov (M1, 1) %0(6, 3)<1> %1(0, 0)<0;1,0>\n"
 +                         "mov (M1, 1) %0(6, 7)<1> %1(0, 0)<0;1,0>\n"
 +                         "mov (M1, 1) %0(7, 3)<1> %1(0, 0)<0;1,0>\n"
 +                         "mov (M1, 1) %0(7, 7)<1> %1(0, 0)<0;1,0>\n"
 +                         : "+rw"(reinterpret_cast<typename message_t::vector_t &>(data))
 +                         : "rw"(pattern));
++#endif
 +}
 +
 +static inline void restore_data(message_t &data)
 +{
++#if defined(XE_PLUS)
++    __asm__ __volatile__("mov (M1, 1) %0(3, 3)<1> %0(0, 15)<0;1,0>\n"
++                         "mov (M1, 1) %0(3, 7)<1> %0(1, 15)<0;1,0>\n"
++                         "mov (M1, 1) %0(3, 11)<1> %0(2, 15)<0;1,0>\n"
++                         : "+rw"(reinterpret_cast<typename message_t::vector_t &>(data))
++                         : );
++#else
 +    __asm__ __volatile__("mov (M1, 1) %0(6, 3)<1> %0(1, 7)<0;1,0>\n"
 +                         "mov (M1, 1) %0(6, 7)<1> %0(3, 7)<0;1,0>\n"
 +                         "mov (M1, 1) %0(7, 3)<1> %0(5, 7)<0;1,0>\n"
 +                         : "+rw"(reinterpret_cast<typename message_t::vector_t &>(data))
 +                         : );
++#endif
 +}
 +#endif
 +
 +static inline void send(char *next, char *src, int lid, int req_workitems,
-+                        const ccl_datatype& dtype, int rank, pattern_t pattern)
++                        const ccl_datatype& dtype, int rank, pattern_t pattern,size_t left_size)
 +{
 +    #if defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
 +    message_t data;
 +    int sz = sizeof(data);
 +
-+    LscLoadCached(data, src + lid * sz);
++    if ((lid < req_workitems) && (lid * sz < left_size))
++        LscLoadCached(data, src + lid * sz);
 +
 +    shuffle_data(data);
 +    insert_pattern(data, pattern);
@@ -529,7 +586,7 @@ index 0000000..15ace74
 +}
 +
 +static inline void recv_reduce_send(char *dst, char *next, char *src, int lid, int req_workitems,
-+                                    const ccl_datatype& dtype, int rank, pattern_t pattern)
++                                    const ccl_datatype& dtype, int rank, pattern_t pattern,size_t left_size)
 +{
 +    #if defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
 +    message_t data;
@@ -539,7 +596,8 @@ index 0000000..15ace74
 +    sync_data(src, data, lid, pattern);
 +    restore_data(data);
 +
-+    data = sum(dst_buf[lid], data, dtype);
++    if ((lid < req_workitems) && (lid * sz < left_size))
++        data = sum(dst_buf[lid], data, dtype);
 +
 +    shuffle_data(data);
 +    insert_pattern(data, pattern);
@@ -548,7 +606,7 @@ index 0000000..15ace74
 +}
 +
 +static inline void recv_reduce_copy_send(char *dst, char *next, char *src, int lid, int req_workitems,
-+                                         const ccl_datatype& dtype, int rank, pattern_t pattern)
++                                         const ccl_datatype& dtype, int rank, pattern_t pattern,size_t left_size)
 +{
 +    #if defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
 +    message_t data;
@@ -558,8 +616,10 @@ index 0000000..15ace74
 +    sync_data(src, data, lid, pattern);
 +    restore_data(data);
 +
-+    data = sum(dst_buf[lid], data, dtype);
-+    if (lid < req_workitems)
++    if ((lid < req_workitems) && (lid * sz < left_size))
++        data = sum(dst_buf[lid], data, dtype);
++
++    if ((lid < req_workitems) && (lid * sz < left_size))
 +        LscStoreUnCached(dst + lid * sz, data);
 +
 +    shuffle_data(data);
@@ -569,7 +629,7 @@ index 0000000..15ace74
 +}
 +
 +static inline void recv_copy_send(char *dst, char *next, char *src, int lid, int req_workitems,
-+                                  const ccl_datatype& dtype, int rank, pattern_t pattern)
++                                  const ccl_datatype& dtype, int rank, pattern_t pattern,size_t left_size)
 +{
 +    #if defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
 +    message_t data;
@@ -580,13 +640,13 @@ index 0000000..15ace74
 +
 +    restore_data(data);
 +
-+    if (lid < req_workitems)
++    if ((lid < req_workitems) && (lid * sz < left_size))
 +        LscStoreUnCached(dst + lid * sz, data);
 +    #endif
 +}
 +
 +static inline void recv(char *dst, char *src, int lid, int req_workitems,
-+                        const ccl_datatype& dtype, int rank, pattern_t pattern)
++                        const ccl_datatype& dtype, int rank, pattern_t pattern,size_t left_size)
 +{
 +    #if defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
 +    message_t data;
@@ -597,7 +657,7 @@ index 0000000..15ace74
 +
 +    restore_data(data);
 +
-+    if (lid < req_workitems)
++    if ((lid < req_workitems) && (lid * sz < left_size))
 +        LscStoreUnCached(dst + lid * sz, data);
 +    #endif
 +}
@@ -727,7 +787,8 @@ index 0000000..15ace74
 +
 +                        char *next = local_peer_bufs[next_rank];
 +
-+                        send(next + offset_with_pattern, send_buf + offset, sg_lid, req_workitems, dtype, local_world_rank, pattern);
++			size_t left_size = count * dt_sz - offset;
++                        send(next + offset_with_pattern, send_buf + offset, sg_lid, req_workitems, dtype, local_world_rank, pattern,left_size);
 +                    }
 +
 +                    // step 2: reduce and copy to next GPU
@@ -739,8 +800,9 @@ index 0000000..15ace74
 +                        char *src = local_host_buf;
 +                        char *next = local_peer_bufs[next_rank];
 +
++			size_t left_size = count * dt_sz - offset;
 +                        recv_reduce_send(recv_buf + offset, next + offset_with_pattern, src + offset_with_pattern,
-+                                         sg_lid, req_workitems, dtype, local_world_rank, pattern);
++                                         sg_lid, req_workitems, dtype, local_world_rank, pattern,left_size);
 +                    }
 +
 +                    // step 3: reduce this buffer and data, which will produce the final
@@ -753,8 +815,9 @@ index 0000000..15ace74
 +                        char *src = local_host_buf;
 +                        char *next = local_peer_bufs[next_rank];
 +
++                        size_t left_size = count * dt_sz - offset;
 +                        recv_reduce_copy_send(recv_buf + offset, next + GATHER_BUF_OFFSET + offset_with_pattern, src + offset_with_pattern,
-+                                              sg_lid, req_workitems, dtype, local_world_rank, pattern);
++                                              sg_lid, req_workitems, dtype, local_world_rank, pattern,left_size);
 +                    }
 +
 +                    // step 4: copy to next GPU
@@ -766,8 +829,9 @@ index 0000000..15ace74
 +                        char *src = local_host_buf;
 +                        char *next = local_peer_bufs[next_rank];
 +
++			size_t left_size = count * dt_sz - offset;
 +                        recv_copy_send(recv_buf + offset, next + offset_with_pattern, src + offset_with_pattern,
-+                                       sg_lid, req_workitems, dtype, local_world_rank, pattern);
++                                       sg_lid, req_workitems, dtype, local_world_rank, pattern,left_size);
 +                    }
 +
 +                    // step 5: Make final copy from buffer to dest
@@ -778,7 +842,8 @@ index 0000000..15ace74
 +
 +                        char *src = local_host_buf;
 +
-+                        recv(recv_buf + offset, src + offset_with_pattern, sg_lid, req_workitems, dtype, local_world_rank, pattern);
++			size_t left_size = count * dt_sz - offset;
++                        recv(recv_buf + offset, src + offset_with_pattern, sg_lid, req_workitems, dtype, local_world_rank, pattern,left_size);
 +                    }
 +                }
 +            }
@@ -829,107 +894,5 @@ index 0000000..0506445
 +
 +void dg2_clear();
 -- 
-2.34.1
-
-
-From 20bfd0e0a37f93dfb8bb9c092cd5a0b35e868bfa Mon Sep 17 00:00:00 2001
-From: Huajun Li <huajun.li@.com>
-Date: Fri, 7 Mar 2025 15:15:35 +0800
-Subject: [PATCH 2/3] optimize req_workgroup calculate
-
----
- src/dg2/dg2_allreduce.cpp | 25 ++-----------------------
- 1 file changed, 2 insertions(+), 23 deletions(-)
-
-diff --git a/src/dg2/dg2_allreduce.cpp b/src/dg2/dg2_allreduce.cpp
-index 15ace74..83270ae 100644
---- a/src/dg2/dg2_allreduce.cpp
-+++ b/src/dg2/dg2_allreduce.cpp
-@@ -527,30 +527,9 @@ ccl::event dg2_ll256_allreduce(const void *src, void *dst, size_t count,
-                 auto chunk_sz = req_workitems * LS_SZ;         /* LS_SZ bytes per work-item */
-                 auto chunk_with_pattern = sg_sz * LS_SZ;       /* aligned to 256B */
- 
--                /* items will be assigned to each rank */
--                auto per_rank_items = (unreduced + (local_world_size * LS_SZ - 1)) / (local_world_size * LS_SZ);
--                auto req_workgroups = (per_rank_items + (workgroup_available_items - 1)) / workgroup_available_items;
--                auto req_subgroups = 0;
--
--                if (req_workgroups >= g_sz/l_sz) {
--                    req_workgroups = g_sz/l_sz;
--                } else {
--                    if (group_id == (req_workgroups - 1)) {
--                        req_subgroups = (per_rank_items + (sg_sz - 1)) / (sg_sz - 1);
--
--                        /* (req_subgroups % (l_sz/sg_sz) - 1) equals to the final subgroup id in a workgroup */
--                        /* Note:  req_subgroups % (l_sz/sg_sz) might be 0 */
--                        if (((req_subgroups % (l_sz/sg_sz)) == 0) || (sg_id == (req_subgroups % (l_sz/sg_sz) - 1))) {
--                            if ((per_rank_items % (sg_sz - 1)) != 0) {
--                                /* FIXME: */
--                                req_workitems = per_rank_items % (sg_sz - 1);
--                                chunk_sz = req_workitems * LS_SZ;    /* LS_SZ bytes per work-item */
--                            }
--                        }
--                    }
--                }
-+		auto work_left = unreduced - sg_id * local_world_size * chunk_sz;
- 
--                if (group_id < req_workgroups) {
-+                if (work_left > 0) {
-                     // step 1: push data to next GPU
-                     {
-                         offset = base + local_world_rank * chunk_sz;
--- 
-2.34.1
-
-
-From 1c58cc9ede5ca38138a270f9e5ff59bca74f51d4 Mon Sep 17 00:00:00 2001
-From: Huajun Li <huajun.li@.com>
-Date: Wed, 12 Mar 2025 13:29:27 +0800
-Subject: [PATCH 3/3] Revert "optimize req_workgroup calculate" for hang issue
-
-This reverts commit 20bfd0e0a37f93dfb8bb9c092cd5a0b35e868bfa.
----
- src/dg2/dg2_allreduce.cpp | 25 +++++++++++++++++++++++--
- 1 file changed, 23 insertions(+), 2 deletions(-)
-
-diff --git a/src/dg2/dg2_allreduce.cpp b/src/dg2/dg2_allreduce.cpp
-index 83270ae..15ace74 100644
---- a/src/dg2/dg2_allreduce.cpp
-+++ b/src/dg2/dg2_allreduce.cpp
-@@ -527,9 +527,30 @@ ccl::event dg2_ll256_allreduce(const void *src, void *dst, size_t count,
-                 auto chunk_sz = req_workitems * LS_SZ;         /* LS_SZ bytes per work-item */
-                 auto chunk_with_pattern = sg_sz * LS_SZ;       /* aligned to 256B */
- 
--		auto work_left = unreduced - sg_id * local_world_size * chunk_sz;
-+                /* items will be assigned to each rank */
-+                auto per_rank_items = (unreduced + (local_world_size * LS_SZ - 1)) / (local_world_size * LS_SZ);
-+                auto req_workgroups = (per_rank_items + (workgroup_available_items - 1)) / workgroup_available_items;
-+                auto req_subgroups = 0;
-+
-+                if (req_workgroups >= g_sz/l_sz) {
-+                    req_workgroups = g_sz/l_sz;
-+                } else {
-+                    if (group_id == (req_workgroups - 1)) {
-+                        req_subgroups = (per_rank_items + (sg_sz - 1)) / (sg_sz - 1);
-+
-+                        /* (req_subgroups % (l_sz/sg_sz) - 1) equals to the final subgroup id in a workgroup */
-+                        /* Note:  req_subgroups % (l_sz/sg_sz) might be 0 */
-+                        if (((req_subgroups % (l_sz/sg_sz)) == 0) || (sg_id == (req_subgroups % (l_sz/sg_sz) - 1))) {
-+                            if ((per_rank_items % (sg_sz - 1)) != 0) {
-+                                /* FIXME: */
-+                                req_workitems = per_rank_items % (sg_sz - 1);
-+                                chunk_sz = req_workitems * LS_SZ;    /* LS_SZ bytes per work-item */
-+                            }
-+                        }
-+                    }
-+                }
- 
--                if (work_left > 0) {
-+                if (group_id < req_workgroups) {
-                     // step 1: push data to next GPU
-                     {
-                         offset = base + local_world_rank * chunk_sz;
--- 
-2.34.1
-
+2.45.2
 

--- a/docker/llm/serving/xpu/docker/Dockerfile
+++ b/docker/llm/serving/xpu/docker/Dockerfile
@@ -157,14 +157,18 @@ RUN set -eux && \
     # Install compute runtime
     mkdir -p /tmp/neo && \
     cd /tmp/neo && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-core-2_2.5.6+18417_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-opencl-2_2.5.6+18417_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-level-zero-gpu-dbgsym_1.6.32224.5_amd64.ddeb && \
-    wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-level-zero-gpu_1.6.32224.5_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-opencl-icd-dbgsym_24.52.32224.5_amd64.ddeb && \
-    wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-opencl-icd_24.52.32224.5_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/libigdgmm12_22.5.5_amd64.deb && \
-    dpkg -i *.deb && rm -rf /tmp/neo && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.8.3/intel-igc-core-2_2.8.3+18762_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.8.3/intel-igc-opencl-2_2.8.3+18762_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.8.3/intel-igc-opencl-devel_2.8.3+18762_amd64.deb && \
+    dpkg -i *.deb && \
+    rm -rf *.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.09.32961.7/libigdgmm12_22.6.0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.09.32961.7/intel-level-zero-gpu-dbgsym_1.6.32961.7_amd64.ddeb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.09.32961.7/intel-level-zero-gpu_1.6.32961.7_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.09.32961.7/intel-opencl-icd-dbgsym_25.09.32961.7_amd64.ddeb && \
+    wget https://github.com/intel/compute-runtime/releases/download/25.09.32961.7/intel-opencl-icd_25.09.32961.7_amd64.deb && \
+    dpkg -i *.deb && \
+    dpkg -i *.ddeb && \
     mkdir -p /llm && \
     cd /llm && \
     rm -rf /tmp/neo && \

--- a/docker/llm/serving/xpu/docker/Dockerfile
+++ b/docker/llm/serving/xpu/docker/Dockerfile
@@ -115,7 +115,7 @@ RUN set -eux && \
     # 
     # Install Python 3.11
     add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt-get install -y --no-install-recommends python3.11 python3-pip python3.11-dev python3.11-distutils python3-wheel && \
+    apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-distutils python3-wheel && \
     rm /usr/bin/python3 && ln -s /usr/bin/python3.11 /usr/bin/python3 && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     # 

--- a/docker/llm/serving/xpu/docker/Dockerfile
+++ b/docker/llm/serving/xpu/docker/Dockerfile
@@ -186,7 +186,10 @@ RUN set -eux && \
     VLLM_TARGET_DEVICE=xpu pip install --no-build-isolation -v /llm/vllm && \
     rm -rf /llm/vllm_for_multi_arc.patch && \
     pip install mpi4py fastapi uvicorn openai && \
-    pip install ray
+    pip install ray && \
+    # Link libze_loader.so
+    cd /usr/lib/x86_64-linux-gnu && \
+    ln -s libze_loader.so.1 libze_loader.so
 
 
 WORKDIR /llm/

--- a/docker/llm/serving/xpu/docker/Dockerfile
+++ b/docker/llm/serving/xpu/docker/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # First stage: build oneccl
-FROM intel/oneapi-basekit:2025.0.1-0-devel-ubuntu22.04 AS build
+FROM intel/oneapi-basekit:2025.0.1-0-devel-ubuntu24.04 AS build
 
 ARG http_proxy
 ARG https_proxy
@@ -32,7 +32,7 @@ RUN set -eux && \
     # 
     # Install Python 3.11
     add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt-get install -y --no-install-recommends python3.11 python3-pip python3.11-dev python3.11-distutils python3-wheel && \
+    apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-distutils python3-wheel && \
     rm /usr/bin/python3 && ln -s /usr/bin/python3.11 /usr/bin/python3 && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     # 
@@ -82,7 +82,7 @@ RUN set -eux && \
 
 
 # Second stage: Final runtime image
-FROM intel/oneapi-basekit:2025.0.1-0-devel-ubuntu22.04
+FROM intel/oneapi-basekit:2025.0.1-0-devel-ubuntu24.04
 
 # Copy the built torch-ccl package from the build stage
 COPY --from=build /build/torch-ccl/dist/oneccl_bind_pt-2.5.0+xpu-cp311-cp311-linux_x86_64.whl /opt/


### PR DESCRIPTION
## Description

Update compute-runtime for BMG support.

Mainly changes:
1. Update compute runtime to newest version
2. Change to use 24.04 operating system.

### 1. Why the change?

The installation of `compute-runtime` requires 2.38 on glibc, which is only available in 24.04

### 2. User API changes

None

### 3. How to test?
- [ ] N/A
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] Application test
- [ ] Document test
- [ ] ...

