### PR TITLE
enable glm4v and gemma-3 on vllm 083

### DIFF
--- a/docker/llm/serving/xpu/docker/vllm_offline_inference_vision_language.py
+++ b/docker/llm/serving/xpu/docker/vllm_offline_inference_vision_language.py
@@ -15,9 +15,7 @@ prompt = "What is in the image?"
 def run_gemma3(question: str, modality: str):
     assert modality == "image"
 
-    prompt = f"<|User|>: <image>\n{question}\n\n<|Assistant|>:"
-
-    prompts =   ("<bos><start_of_turn>user\n"
+    prompt =   ("<bos><start_of_turn>user\n"
                 f"<start_of_image>{question}<end_of_turn>\n"
                  "<start_of_turn>model\n")
     stop_token_ids = None
@@ -105,7 +103,9 @@ llm = LLM(
           device="xpu",
           dtype=dtype,
           enforce_eager=True,
-          load_in_low_bit="fp8",
+          hf_overrides=hf_override,
+          mm_processor_kwargs=mm_processor_kwarg,
+          load_in_low_bit="sym_int4",
           tensor_parallel_size=2,
           disable_async_output_proc=True,
           distributed_executor_backend="ray",

--- a/docker/llm/serving/xpu/docker/vllm_offline_inference_vision_language.py
+++ b/docker/llm/serving/xpu/docker/vllm_offline_inference_vision_language.py
@@ -9,6 +9,7 @@ model_path = "/llm/models/Qwen2-VL-7B-Instruct"
 model_path = "/llm/models/glm-4v-9b"
 model_path = "/llm/models/InternVL2-8B"
 model_path = "/llm/models/gemma-3-12b-it"
+model_path = "/llm/models/Qwen2.5-VL-7B-Instruct"
 
 prompt = "What is in the image?"
 
@@ -79,6 +80,7 @@ def run_qwen2_vl(question, modality):
 model_example_map = {
     "minicpmv": run_minicpmv,
     "qwen2_vl": run_qwen2_vl,
+    "qwen2_5_vl": run_qwen2_vl,
     # only for glm4v
     "chatglm": run_glm4v,
     "internvl_chat": run_internvl,

--- a/docker/llm/serving/xpu/docker/vllm_offline_inference_vision_language.py
+++ b/docker/llm/serving/xpu/docker/vllm_offline_inference_vision_language.py
@@ -8,8 +8,20 @@ model_path = "/llm/models/MiniCPM-V-2_6"
 model_path = "/llm/models/Qwen2-VL-7B-Instruct"
 model_path = "/llm/models/glm-4v-9b"
 model_path = "/llm/models/InternVL2-8B"
+model_path = "/llm/models/gemma-3-12b-it"
 
 prompt = "What is in the image?"
+
+def run_gemma3(question: str, modality: str):
+    assert modality == "image"
+
+    prompt = f"<|User|>: <image>\n{question}\n\n<|Assistant|>:"
+
+    prompts =   ("<bos><start_of_turn>user\n"
+                f"<start_of_image>{question}<end_of_turn>\n"
+                 "<start_of_turn>model\n")
+    stop_token_ids = None
+    return prompt, stop_token_ids
 
 def run_internvl(question: str, modality: str):
     assert modality == "image"
@@ -72,15 +84,29 @@ model_example_map = {
     # only for glm4v
     "chatglm": run_glm4v,
     "internvl_chat": run_internvl,
+    "gemma3": run_gemma3,
 }
+
+if "glm-4v" in model_path:
+    hf_override = {"architectures": ["GLM4VForCausalLM"]}
+else:
+    hf_override = None
+
+dtype = "float16"
+if "gemma-3" in model_path:
+    mm_processor_kwarg = {"do_pan_and_scan": True}
+    dtype = "float32"
+else:
+    mm_processor_kwarg = None
+
 
 llm = LLM(
           model=model_path,
           device="xpu",
-          dtype="float16",
+          dtype=dtype,
           enforce_eager=True,
           load_in_low_bit="fp8",
-          tensor_parallel_size=1,
+          tensor_parallel_size=2,
           disable_async_output_proc=True,
           distributed_executor_backend="ray",
           max_model_len=4000,

--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -77,7 +77,8 @@ def _ipex_llm_convert(load_in_low_bit):
 
 def get_load_function(low_bit):
     def _ipex_llm_load_model(self) -> None:
-        _model_sample_convert()
+        if "gemma-3" not in self.model_config.model.lower():
+            _model_sample_convert()
 
         # from vllm.utils import measure_device_memory
         from vllm.utils import DeviceMemoryProfiler


### PR DESCRIPTION
## Description
enable glm4v and gemma-3 and qwen2.5 on vllm 083 with this pr on vllm https://github.com/analytics-zoo/vllm/pull/105.

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
