### PR TITLE
vLLM: set convert_to_half to False by default

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -293,6 +293,7 @@ def convert_vllm(module, qtype, in_features, out_features, mp_group, cur_qtype,
                 mp_group=mp_group,
                 optimize_lm_head=optimize_lm_head,
                 enable_scale_search=enable_scale_search,
+                conver_to_half=False,
             )
     return new_linear
 
@@ -589,6 +590,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             optimize_lm_head=False,
                             act_order=act_order,
                             enable_scale_search=enable_scale_search,
+                            conver_to_half=False,
                         )
                         device = module.qweight.data.device
                         invalidInputError(device.type != "meta",

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -273,7 +273,7 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
     device_name = get_xpu_device_name(x.device)
     batch_size = x.shape[0]
     hard_condition = (
-        x.dtype in [torch.float, torch.half]
+        x.dtype in [torch.half]
         and x.shape[1] % 128 == 0
         and (
             (
@@ -875,7 +875,7 @@ class BF16Linear(nn.Linear):
 
 class vLLMLowBitLinear(LowBitLinear):
     def __init__(self, input_features, output_features, qtype, bias=True,
-                 conver_to_half=True, mp_group=None,
+                 conver_to_half=False, mp_group=None,
                  optimize_lm_head=False, act_order=False,
                  enable_scale_search=False):
         super().__init__(input_features, output_features, qtype, bias, conver_to_half, mp_group,

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -273,7 +273,7 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
     device_name = get_xpu_device_name(x.device)
     batch_size = x.shape[0]
     hard_condition = (
-        x.dtype in [torch.half]
+        x.dtype in [torch.float, torch.half]
         and x.shape[1] % 128 == 0
         and (
             (
@@ -654,7 +654,7 @@ class LowBitLinear(nn.Linear):
                 else:
                     w = self.weight.data
 
-                if use_batch_forward(x_2d, self.weight.qtype, self.out_len):
+                if use_batch_forward(x_2d, self.weight.qtype, self.out_len) and self.conver_to_half:
                     import xe_batch
                     result = xe_batch.batch_forward(x_2d, w, self.qtype)
                 elif not is_training and self.conver_to_half \
@@ -875,7 +875,7 @@ class BF16Linear(nn.Linear):
 
 class vLLMLowBitLinear(LowBitLinear):
     def __init__(self, input_features, output_features, qtype, bias=True,
-                 conver_to_half=False, mp_group=None,
+                 conver_to_half=True, mp_group=None,
                  optimize_lm_head=False, act_order=False,
                  enable_scale_search=False):
         super().__init__(input_features, output_features, qtype, bias, conver_to_half, mp_group,

--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -145,6 +145,7 @@ def get_load_function(low_bit):
 
         self.model_memory_usage = m.consumed_memory
         logger = init_logger(__name__)
+        logger.info(self.model)
         logger.info("Loading model weights took %.4f GB",
                     self.model_memory_usage / float(2**30))
 

--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -145,7 +145,6 @@ def get_load_function(low_bit):
 
         self.model_memory_usage = m.consumed_memory
         logger = init_logger(__name__)
-        logger.info(self.model)
         logger.info("Loading model weights took %.4f GB",
                     self.model_memory_usage / float(2**30))
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Calculate dtype fp32 with no convert_to_half  for better accuracy
