### PR TITLE
vLLM: Fix conver_to_half condition 

### DIFF
--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -654,7 +654,7 @@ class LowBitLinear(nn.Linear):
                 else:
                     w = self.weight.data
 
-                if use_batch_forward(x_2d, self.weight.qtype, self.out_len) and self.conver_to_half:
+                if use_batch_forward(x_2d, self.weight.qtype, self.out_len) and (x_2d.dtype == torch.half or self.conver_to_half):
                     import xe_batch
                     result = xe_batch.batch_forward(x_2d, w, self.qtype)
                 elif not is_training and self.conver_to_half \

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -654,7 +654,8 @@ class LowBitLinear(nn.Linear):
                 else:
                     w = self.weight.data
 
-                if use_batch_forward(x_2d, self.weight.qtype, self.out_len) and (x_2d.dtype == torch.half or self.conver_to_half):
+                if use_batch_forward(x_2d, self.weight.qtype, self.out_len) and \
+                        (x_2d.dtype == torch.half or self.conver_to_half):
                     import xe_batch
                     result = xe_batch.batch_forward(x_2d, w, self.qtype)
                 elif not is_training and self.conver_to_half \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Found by Jian. Only need to check `self.conver_to_half` flag when x_2d.dtype is not half.