### PR TITLE
only install onednn for windows when torch 2.6

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -304,10 +304,10 @@ def setup_package():
                         "torchvision==0.21.0+xpu",
                         "torchaudio==2.6.0+xpu",
                         "bigdl-core-xe-all==" + CORE_XE_VERSION,
-                        "onednn-devel==2025.0.1",
-                        "onednn==2025.0.1",
+                        "onednn-devel==2025.0.1;platform_system=='Windows'",
+                        "onednn==2025.0.1;platform_system=='Windows'",
                         "dpcpp-cpp-rt==2025.0.2"]
-    
+
     # Add for testing purposes for now, for Arrow Lake-H with AOT on Windows
     # Linux keeps the same as xpu_2.6
     xpu_26_arl_requires = copy.deepcopy(all_requires)
@@ -320,8 +320,8 @@ def setup_package():
                             "torchvision==0.21.0+xpu;platform_system=='Linux'",
                             "torchaudio==2.6.0+xpu;platform_system=='Linux'",
                             "bigdl-core-xe-all==" + CORE_XE_VERSION,
-                            "onednn-devel==2025.0.1",
-                            "onednn==2025.0.1",
+                            "onednn-devel==2025.0.1;platform_system=='Windows'",
+                            "onednn==2025.0.1;platform_system=='Windows'",
                             "dpcpp-cpp-rt==2025.0.2"]
 
     cpp_requires = ["bigdl-core-cpp==" + CORE_XE_VERSION,


### PR DESCRIPTION
## Description

### 1. Why the change?

related issue: https://github.com/analytics-zoo/nano/issues/1960#issuecomment-2943157670
- only install onednn for windows when torch 2.6 as now we have built-in onednn on Linux

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] local test on BMG